### PR TITLE
synch --live-replay feature with playitagainsam, or maybe not

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,4 +33,8 @@ Or by passing in a javascript object with the script data already loaded::
 
 Pass a callback function as second argument if you want to know when the
 session as finished being player.  Call the "destroy()" method if you want
-to tear down the player early.  Watch this space for better documentation...
+to tear down the player early.  
+
+An option for live replay of playtagainsam recorded sessions is not planned.
+
+Watch this space for better documentation...


### PR DESCRIPTION
Not planning a --live-replay feature for playitagainsam.js,
though it would be easy to do by remote serving the actual terminal
and adding a --server --port=localport option to playitagainsam.

Then, the js call would be something like:

```
player.live-replay("./path/to/terminal-session.js", localport);
```

But I'm not going to do it, because that's wholly unnecessary.

I'm just doing this because it's always good to comment on feature
parity between compatible projects.

And to bump playitagainsam up in your queue :).
